### PR TITLE
Declare nix substituters (cache.nixos.org, nix-community and flox)

### DIFF
--- a/non-critical-infra/modules/common.nix
+++ b/non-critical-infra/modules/common.nix
@@ -29,6 +29,16 @@
     extraOptions = ''
       experimental-features = nix-command flakes
     '';
+    substituters = [
+      "https://cache.nixos.org"
+      "https://nix-community.cachix.org"
+      "https://cache.flox.dev"
+    ];
+    trusted-public-keys = [
+      "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+      "flox-cache-public-1:7F4OyH7ZCnFhcze3fJdfyXYLQw/aV7GEed86nQ7IsOs="
+    ];
   };
 
   # Fish shell


### PR DESCRIPTION
Let's add the following substituters.
Flox now caches several cuda packages: https://flox.dev/blog/the-flox-catalog-now-contains-nvidia-cuda/
